### PR TITLE
Add coverage configuration and basic unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ addopts = "-s --tb=native -v --durations=10"
 norecursedirs = ["build", "dist"]
 asyncio_default_fixture_loop_scope = "function"
 
+[tool.coverage.run]
+source = ["bulkllm"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
 [tool.ty.terminal]
 output-format = "concise"
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,26 @@
+import datetime
+
+from bulkllm.schema import LLMConfig
+
+LLMConfig.model_rebuild(_types_namespace={"datetime": datetime})
+
+
+def test_llmconfig_md5_and_kwargs():
+    cfg1 = LLMConfig(
+        slug="s1",
+        display_name="S1",
+        company_name="ACME",
+        litellm_model_name="model-1",
+        temperature=0.1,
+        max_tokens=100,
+        system_prompt="hello",
+    )
+    cfg2 = cfg1.model_copy(update={"temperature": 0.2})
+
+    assert cfg1.md5_hash != cfg2.md5_hash
+
+    kwargs = cfg1.completion_kwargs()
+    assert kwargs["model"] == "model-1"
+    assert kwargs["temperature"] == 0.1
+    assert kwargs["max_tokens"] == 100
+    assert kwargs["stream"] is False

--- a/tests/test_usage_tracker.py
+++ b/tests/test_usage_tracker.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+from typing import Any, cast
+
+from bulkllm.usage_tracker import (
+    GLOBAL_TRACKER,
+    UsageTracker,
+    convert_litellm_usage_to_usage_record,
+    track_usage,
+)
+
+
+class Dummy(SimpleNamespace):
+    pass
+
+
+def test_convert_usage_no_details():
+    usage = Dummy(prompt_tokens=5, completion_tokens=7, total_tokens=12)
+    rec = convert_litellm_usage_to_usage_record(cast("dict[str, Any]", usage), model="m")
+    assert rec.input_text_tokens == 5
+    assert rec.output_text_tokens == 7
+    assert rec.tokens_total == 12
+
+
+def test_convert_usage_with_details():
+    prompt_details = Dummy(text_tokens=3, image_tokens=2, audio_tokens=None, cached_tokens=None)
+    completion_details = Dummy(
+        text_tokens=6, audio_tokens=1, reasoning_tokens=0, accepted_prediction_tokens=0, rejected_prediction_tokens=0
+    )
+    usage = Dummy(
+        prompt_tokens=5,
+        completion_tokens=7,
+        total_tokens=12,
+        prompt_tokens_details=prompt_details,
+        completion_tokens_details=completion_details,
+    )
+    rec = convert_litellm_usage_to_usage_record(cast("dict[str, Any]", usage), model="m")
+    assert rec.input_image_tokens == 2
+    assert rec.output_audio_tokens == 1
+    assert rec.tokens_total == 12
+
+
+def test_usage_tracker_aggregate():
+    GLOBAL_TRACKER._aggregates.clear()
+    tracker = UsageTracker("t")
+    with tracker:
+        track_usage(
+            "m",
+            input_text_tokens=1,
+            input_tokens_total=1,
+            output_text_tokens=2,
+            output_tokens_total=2,
+            tokens_total=3,
+            cost_usd=0.1,
+        )
+    stats = tracker.aggregate_stats()["m"]
+    assert stats.request_count.total == 1
+    assert stats.stats["input_text_tokens"].total == 1
+    assert stats.stats["output_text_tokens"].total == 2
+    assert stats.stats["tokens_total"].total == 3


### PR DESCRIPTION
## Summary
- configure coverage via `pyproject.toml` instead of `.coveragerc`
- implement tests for `LLMConfig` utilities
- implement tests for usage tracking helpers

## Testing
- `make checku`
- `make coverage`
