### PR TITLE
Add model registration for additional providers

### DIFF
--- a/bulkllm/model_registration/anthropic.py
+++ b/bulkllm/model_registration/anthropic.py
@@ -1,0 +1,43 @@
+import logging
+import os
+from functools import cache
+from typing import Any
+
+import litellm
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def get_anthropic_models() -> dict[str, Any]:
+    """Return models from the Anthropic list endpoint."""
+    url = "https://api.anthropic.com/v1/models"
+    api_key = os.getenv("ANTHROPIC_API_KEY", "")
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "Content-Type": "application/json",
+    }
+    try:
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:  # noqa: PERF203 - broad catch ok here
+        logger.warning("Failed to fetch Anthropic models: %s", exc)
+        return {}
+    models: dict[str, Any] = {}
+    for item in data.get("data", []):
+        model_id = item.get("id")
+        if model_id:
+            models[f"anthropic/{model_id}"] = {
+                "litellm_provider": "anthropic",
+                "mode": "chat",
+            }
+    return models
+
+
+@cache
+def register_anthropic_models_with_litellm() -> None:
+    """Fetch and register Anthropic models with LiteLLM."""
+    litellm.register_model(get_anthropic_models())

--- a/bulkllm/model_registration/gemini.py
+++ b/bulkllm/model_registration/gemini.py
@@ -1,0 +1,40 @@
+import logging
+import os
+from functools import cache
+from typing import Any
+
+import litellm
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def get_gemini_models() -> dict[str, Any]:
+    """Return models from the Google Gemini list endpoint."""
+    api_key = os.getenv("GEMINI_API_KEY", "")
+    url = "https://generativelanguage.googleapis.com/v1beta/models"
+    params = {"key": api_key} if api_key else None
+    try:
+        resp = requests.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:  # noqa: PERF203 - broad catch ok here
+        logger.warning("Failed to fetch Gemini models: %s", exc)
+        return {}
+    models: dict[str, Any] = {}
+    for item in data.get("models", []):
+        name = item.get("name")
+        if name:
+            model_id = name.split("/")[-1]
+            models[f"gemini/{model_id}"] = {
+                "litellm_provider": "gemini",
+                "mode": "chat",
+            }
+    return models
+
+
+@cache
+def register_gemini_models_with_litellm() -> None:
+    """Fetch and register Gemini models with LiteLLM."""
+    litellm.register_model(get_gemini_models())

--- a/bulkllm/model_registration/main.py
+++ b/bulkllm/model_registration/main.py
@@ -3,6 +3,11 @@ from functools import cache
 
 import litellm
 
+from bulkllm.model_registration.anthropic import (
+    register_anthropic_models_with_litellm,
+)
+from bulkllm.model_registration.gemini import register_gemini_models_with_litellm
+from bulkllm.model_registration.openai import register_openai_models_with_litellm
 from bulkllm.model_registration.openrouter import register_openrouter_models_with_litellm
 
 logger = logging.getLogger(__name__)
@@ -68,4 +73,7 @@ def manual_registration():
 def register_models():
     logger.info("Registering models with LiteLLM")
     register_openrouter_models_with_litellm()
+    register_openai_models_with_litellm()
+    register_anthropic_models_with_litellm()
+    register_gemini_models_with_litellm()
     manual_registration()

--- a/bulkllm/model_registration/openai.py
+++ b/bulkllm/model_registration/openai.py
@@ -1,0 +1,39 @@
+import logging
+import os
+from functools import cache
+from typing import Any
+
+import litellm
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+@cache
+def get_openai_models() -> dict[str, Any]:
+    """Return models from the OpenAI list endpoint."""
+    url = "https://api.openai.com/v1/models"
+    api_key = os.getenv("OPENAI_API_KEY", "")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        data = resp.json()
+    except requests.RequestException as exc:  # noqa: PERF203 - broad catch ok here
+        logger.warning("Failed to fetch OpenAI models: %s", exc)
+        return {}
+    models: dict[str, Any] = {}
+    for item in data.get("data", []):
+        model_id = item.get("id")
+        if model_id:
+            models[f"openai/{model_id}"] = {
+                "litellm_provider": "openai",
+                "mode": "chat",
+            }
+    return models
+
+
+@cache
+def register_openai_models_with_litellm() -> None:
+    """Fetch and register OpenAI models with LiteLLM."""
+    litellm.register_model(get_openai_models())

--- a/tests/test_model_registration/test_providers.py
+++ b/tests/test_model_registration/test_providers.py
@@ -1,0 +1,70 @@
+import requests
+
+from bulkllm.model_registration.anthropic import get_anthropic_models
+from bulkllm.model_registration.gemini import get_gemini_models
+from bulkllm.model_registration.openai import get_openai_models
+
+
+class DummyResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return self._data
+
+
+def _patch_get(monkeypatch, data):
+    def fake_get(*args, **kwargs):
+        return DummyResponse(data)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+
+def test_get_openai_models(monkeypatch):
+    sample = {"data": [{"id": "gpt-4o-mini", "object": "model", "owned_by": "openai", "permission": []}]}
+    get_openai_models.cache_clear()
+    _patch_get(monkeypatch, sample)
+    models = get_openai_models()
+    assert models == {"openai/gpt-4o-mini": {"litellm_provider": "openai", "mode": "chat"}}
+
+
+def test_get_anthropic_models(monkeypatch):
+    sample = {
+        "data": [
+            {
+                "id": "claude-3-7-sonnet-20250219",
+                "display_name": "Claude",
+                "created_at": "2025-02-19T00:00:00Z",
+                "type": "model",
+            }
+        ],
+        "first_id": "claude-3-7-sonnet-20250219",
+        "last_id": "claude-2-1",
+        "has_more": True,
+    }
+    get_anthropic_models.cache_clear()
+    _patch_get(monkeypatch, sample)
+    models = get_anthropic_models()
+    assert models == {"anthropic/claude-3-7-sonnet-20250219": {"litellm_provider": "anthropic", "mode": "chat"}}
+
+
+def test_get_gemini_models(monkeypatch):
+    sample = {
+        "models": [
+            {
+                "name": "models/gemini-1.5-flash-001",
+                "baseModelId": "gemini-1.5-flash",
+                "version": "1.0",
+                "displayName": "Gemini 1.5 Flash",
+                "description": "High-performance LLM",
+            }
+        ],
+        "nextPageToken": "tok",
+    }
+    get_gemini_models.cache_clear()
+    _patch_get(monkeypatch, sample)
+    models = get_gemini_models()
+    assert models == {"gemini/gemini-1.5-flash-001": {"litellm_provider": "gemini", "mode": "chat"}}


### PR DESCRIPTION
## Summary
- implement registration modules for OpenAI, Anthropic and Gemini
- call the new registration functions from the main registration utility
- test provider model loading logic

## Testing
- `make checku`