### PR TITLE
Add Typer CLI and list-models command

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import litellm
+import typer
+
+from bulkllm.model_registration.main import register_models
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+@app.callback(invoke_without_command=True)
+def main_callback() -> None:
+    """BulkLLM command line interface."""
+
+
+@app.command("list-models")
+def list_models() -> None:
+    """List all models registered with LiteLLM."""
+    register_models()
+    for model in sorted(litellm.model_cost):
+        typer.echo(model)
+
+
+def main() -> None:  # pragma: no cover - CLI entry point
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI runner
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
 ]
 license = "MIT"
 
+[project.scripts]
+bulkllm = "bulkllm.cli:app"
+
 [dependency-groups]
 dev = [
     "ty",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+from typer.testing import CliRunner
+
+from bulkllm.cli import app
+
+
+def test_list_models(monkeypatch):
+    import litellm
+
+    # Ensure a clean slate
+    monkeypatch.setattr(litellm, "model_cost", {})
+
+    def fake_register_models() -> None:
+        litellm.model_cost["fake/model"] = {
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+
+    monkeypatch.setattr("bulkllm.cli.register_models", fake_register_models)
+    monkeypatch.setattr("bulkllm.model_registration.main.register_models", fake_register_models)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-models"])
+    assert result.exit_code == 0
+    assert "fake/model" in result.output


### PR DESCRIPTION
## Summary
- implement CLI with Typer
- add `list-models` command to display all registered LiteLLM models
- expose CLI as `bulkllm` entry point
- test CLI behaviour

## Testing
- `make checku`