### PR TITLE
Switch LLMTaskRunner to global semaphore

### DIFF
--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -14,15 +14,16 @@ async def _dummy_call(rl: RateLimiter, model: str, record: list[float]) -> None:
         await ctx.record_usage(1, 1)
 
 
-@pytest.mark.anyio(backend="asyncio")
-async def test_runner_separate_queues() -> None:
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"])
+async def test_runner_separate_queues(anyio_backend: str) -> None:
     rl = RateLimiter(
         [
             ModelRateLimit(model_names=["a"], rpm=1, window_seconds=1),
             ModelRateLimit(model_names=["b"], rpm=1, window_seconds=1),
         ]
     )
-    runner = LLMTaskRunner(rate_limiter=rl, max_workers_per_model=1)
+    runner = LLMTaskRunner(rate_limiter=rl, max_workers=2)
     starts_a: list[float] = []
     starts_b: list[float] = []
 
@@ -32,7 +33,8 @@ async def test_runner_separate_queues() -> None:
         LLMTask("a", 1, 1, lambda: _dummy_call(rl, "a", starts_a)),
     ]
     runner.add_tasks(tasks)
-    await runner.run()
+    with anyio.fail_after(10):
+        await runner.run()
 
     assert len(starts_a) == 2
     assert len(starts_b) == 1


### PR DESCRIPTION
## Summary
- implement a global concurrency semaphore in `LLMTaskRunner`
- wait for capacity using `RateLimiter.await_capacity`
- update the task runner test to use the new API and add a timeout

## Testing
- `make checku`