### PR TITLE
Add CLI command to list models missing rate limits

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -4,6 +4,7 @@ import litellm
 import typer
 
 from bulkllm.model_registration.main import register_models
+from bulkllm.rate_limiter import RateLimiter
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 
@@ -19,6 +20,16 @@ def list_models() -> None:
     register_models()
     for model in sorted(litellm.model_cost):
         typer.echo(model)
+
+
+@app.command("list-missing-rate-limits")
+def list_missing_rate_limits() -> None:
+    """List models without a configured rate limit."""
+    register_models()
+    limiter = RateLimiter()
+    for model in sorted(litellm.model_cost):
+        if limiter.get_rate_limit_for_model(model) is limiter.default_rate_limit:
+            typer.echo(model)
 
 
 def main() -> None:  # pragma: no cover - CLI entry point

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,3 +22,40 @@ def test_list_models(monkeypatch):
     result = runner.invoke(app, ["list-models"])
     assert result.exit_code == 0
     assert "fake/model" in result.output
+
+
+def test_list_missing_rate_limits(monkeypatch):
+    import litellm
+
+    monkeypatch.setattr(litellm, "model_cost", {})
+
+    def fake_register_models() -> None:
+        litellm.model_cost["limited/model"] = {
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+        litellm.model_cost["unlimited/model"] = {
+            "litellm_provider": "openai",
+            "mode": "chat",
+        }
+
+    class DummyRateLimiter:
+        def __init__(self) -> None:
+            self.default_rate_limit = object()
+
+        def get_rate_limit_for_model(self, model: str) -> object:
+            if model == "limited/model":
+                return object()
+            return self.default_rate_limit
+
+    monkeypatch.setattr("bulkllm.cli.register_models", fake_register_models)
+    monkeypatch.setattr("bulkllm.model_registration.main.register_models", fake_register_models)
+    monkeypatch.setattr("bulkllm.cli.RateLimiter", DummyRateLimiter)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-missing-rate-limits"])
+
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    assert "unlimited/model" in lines
+    assert "limited/model" not in lines


### PR DESCRIPTION
## Summary
- add `list-missing-rate-limits` command to CLI
- test new CLI command

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_683a29a09ad8833197e462894e294703