### PR TITLE
Expand OpenAI model registration

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from huggingface_hub import model_info
 import litellm
 import typer
 
 from bulkllm.llm_configs import create_model_configs
+from bulkllm.model_registration.canonical import _canonical_model_name
 from bulkllm.model_registration.main import register_models
 from bulkllm.rate_limiter import RateLimiter
-
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 
@@ -22,7 +21,6 @@ def list_models() -> None:
     """List all models registered with LiteLLM."""
     register_models()
     for model, model_info in sorted(litellm.model_cost.items()):
-        
         typer.echo(model)
 
 

--- a/bulkllm/model_registration/canonical.py
+++ b/bulkllm/model_registration/canonical.py
@@ -4,7 +4,8 @@ from bulkllm.model_registration.main import register_models
 
 primary_providers = {"openai", "anthropic", "gemini", "xai", "qwen", "deepseek", "mistral"}
 
-def _canonical_model_name(name: str, model_info) -> str:
+
+def _canonical_model_name(name: str, model_info) -> str | None:
     """Return canonical name for ``name`` dropping provider wrappers."""
     name = name.replace("/x-ai/", "/xai/")
     if name.startswith("x-ai/"):
@@ -13,7 +14,6 @@ def _canonical_model_name(name: str, model_info) -> str:
     if model_info.get("mode") in ("image_generation", "embedding"):
         return None
 
-    
     provider = model_info.get("litellm_provider")
     if provider == "text-completion-openai":
         return None
@@ -25,18 +25,19 @@ def _canonical_model_name(name: str, model_info) -> str:
             return name
         if "/" not in name:
             return f"{provider}/{name}"
-        raise ValueError(f"Invalid model name: {name}")
-        
+        msg = f"Invalid model name: {name}"
+        raise ValueError(msg)
+
     for p in primary_providers:
         if p in name:
             return None
-    
+
     if name.startswith("openrouter/"):
         name = name[len("openrouter/") :]
         return name
     if name.startswith("bedrock/"):
         after = name[len("bedrock/") :]
-        if not 'nova' in after:
+        if "nova" not in after:
             return None
         return after
 
@@ -52,9 +53,7 @@ def canonical_models():
             continue
         unique.add(canonical)
 
-
-    
-    return sorted(list(unique))
+    return sorted(unique)
 
 
 def model_modes():
@@ -62,8 +61,8 @@ def model_modes():
     modes: set[str] = set()
     for model, model_info in litellm.model_cost.items():
         modes.add(str(model_info.get("mode")))
-    
-    return sorted(list(modes))
+
+    return sorted(modes)
 
 
 def model_providers():
@@ -71,8 +70,9 @@ def model_providers():
     providers: set[str] = set()
     for model, model_info in litellm.model_cost.items():
         providers.add(str(model_info.get("litellm_provider")))
-    
-    return sorted(list(providers))
+
+    return sorted(providers)
+
 
 def text_models():
     register_models()
@@ -86,7 +86,7 @@ def text_models():
             if "/" not in model:
                 model = f"{model_info.get('litellm_provider')}/{model}"
             models[model] = model_info
-    
+
     return models
 
 
@@ -99,7 +99,7 @@ def _primary_provider_model_names():
             if model_name in model_names:
                 print(f"ERROR: Duplicate model name: {model_name}")
             model_names.add(model_name)
-    return sorted(list(model_names))
+    return sorted(model_names)
 
 
 if __name__ == "__main__":

--- a/bulkllm/model_registration/openai.py
+++ b/bulkllm/model_registration/openai.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import os
 from functools import cache
+from importlib import resources
 from typing import Any
 
 import requests
@@ -12,6 +14,59 @@ from bulkllm.model_registration.utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _load_detailed_data() -> dict[str, Any]:
+    """Return the bundled OpenAI detailed JSON."""
+
+    resource = resources.files("bulkllm.model_registration.data").joinpath("openai_detailed.json")
+    with resources.as_file(resource) as path, open(path) as f:
+        return json.load(f)
+
+
+@cache
+def _get_detailed_lookup() -> dict[str, dict[str, Any]]:
+    """Return mapping of model slug to detailed info."""
+
+    data = _load_detailed_data()
+    lookup: dict[str, dict[str, Any]] = {}
+
+    for item in data.get("modalities", []):
+        slug = item.get("slug") or item.get("name")
+        if slug:
+            lookup.setdefault(slug, {})["modalities"] = item
+
+    for item in data.get("pricing", []):
+        base_slugs = set()
+        if item.get("current_snapshot"):
+            base_slugs.add(item["current_snapshot"])
+        if item.get("name"):
+            base_slugs.add(item["name"])
+
+        snapshots = item.get("snapshots") or []
+        for snap in snapshots:
+            if isinstance(snap, str):
+                snap_name = snap
+                snap_values = None
+            else:
+                snap_name = snap.get("name")
+                snap_values = snap.get("values")
+            if snap_name:
+                base_slugs.add(snap_name)
+                snap_item = {**item, "current_snapshot": snap_name}
+                if snap_values is not None:
+                    snap_item["values"] = snap_values
+                lookup.setdefault(snap_name, {})["pricing"] = snap_item
+
+        for slug in base_slugs:
+            lookup.setdefault(slug, {})["pricing"] = item
+
+    for item in data.get("rate_limits", []):
+        slug = item.get("slug") or item.get("name")
+        if slug:
+            lookup.setdefault(slug, {})["rate_limits"] = item
+
+    return lookup
 
 
 def convert_openai_to_litellm(openai_model: dict[str, Any]) -> dict[str, Any] | None:
@@ -34,6 +89,99 @@ def convert_openai_to_litellm(openai_model: dict[str, Any]) -> dict[str, Any] | 
             model_info[field] = value
 
     return {"model_name": litellm_model_name, "model_info": model_info}
+
+
+def _convert_detailed_to_litellm(slug: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Convert bundled detailed info for one model."""
+
+    model_info: dict[str, Any] = {
+        "litellm_provider": "openai",
+        "mode": "chat",
+    }
+
+    modalities = data.get("modalities")
+    if modalities:
+        mods_in = modalities.get("modalities", {}).get("input", [])
+        mods_out = modalities.get("modalities", {}).get("output", [])
+
+        if "image" in mods_out and "text" in mods_in:
+            model_info["mode"] = "image_generation"
+        elif "audio" in mods_in and "text" in mods_out:
+            model_info["mode"] = "audio_transcription"
+        elif "text" in mods_in and "audio" in mods_out:
+            model_info["mode"] = "audio_speech"
+
+        if "image" in mods_in or "image" in mods_out:
+            model_info["supports_vision"] = True
+        if "audio" in mods_in:
+            model_info["supports_audio_input"] = True
+        if "audio" in mods_out:
+            model_info["supports_audio_output"] = True
+
+        context = modalities.get("context_window")
+        if context is not None:
+            model_info["max_input_tokens"] = context
+
+        max_output = modalities.get("max_output_tokens")
+        if max_output is not None:
+            model_info["max_output_tokens"] = max_output
+
+        supported = set(modalities.get("supported_features", []))
+        if "streaming" in supported:
+            model_info["supports_prompt_caching"] = True
+        if "function_calling" in supported:
+            model_info["supports_function_calling"] = True
+            model_info["supports_parallel_function_calling"] = True
+
+        if modalities.get("reasoning_tokens"):
+            model_info["supports_reasoning"] = True
+
+        price_data = modalities.get("price_data", {}).get("main", {})
+        if price_data:
+            inp = price_data.get("input")
+            out = price_data.get("output")
+            reasoning = price_data.get("reasoning")
+            if inp is not None:
+                model_info["input_cost_per_token"] = float(inp) / 1_000_000
+            if out is not None:
+                model_info["output_cost_per_token"] = float(out) / 1_000_000
+            if reasoning is not None:
+                model_info["output_cost_per_reasoning_token"] = float(reasoning) / 1_000_000
+
+    pricing = data.get("pricing")
+    if pricing:
+        values = pricing.get("values", {}).get("main", {})
+        if values:
+            inp = values.get("input")
+            out = values.get("output")
+            reasoning = values.get("reasoning")
+            if inp is not None:
+                model_info["input_cost_per_token"] = float(inp) / 1_000_000
+            if out is not None:
+                model_info["output_cost_per_token"] = float(out) / 1_000_000
+            if reasoning is not None:
+                model_info["output_cost_per_reasoning_token"] = float(reasoning) / 1_000_000
+
+        if pricing.get("deprecation_date"):
+            model_info["deprecation_date"] = pricing["deprecation_date"]
+
+    rl = data.get("rate_limits")
+    if rl:
+        if isinstance(rl.get("rate_limits"), list):
+            rl_entry = rl.get("rate_limits")[0] if rl.get("rate_limits") else {}
+            tiers = rl_entry.get("rate_limits", {})
+        else:
+            tiers = rl.get("rate_limits", {})
+        tier1 = tiers.get("tier_1", {})
+        rpm = tier1.get("rpm")
+        tpm = tier1.get("tpm")
+        if rpm is not None:
+            model_info["rpm"] = rpm
+        if tpm is not None:
+            model_info["tpm"] = tpm
+
+    model_info = {k: v for k, v in model_info.items() if v is not None}
+    return {"model_name": f"openai/{slug}", "model_info": model_info}
 
 
 @cache
@@ -61,6 +209,14 @@ def get_openai_models(*, use_cached: bool = True) -> dict[str, Any]:
         converted = convert_openai_to_litellm(item)
         if converted:
             models[converted["model_name"]] = converted["model_info"]
+
+    for slug, details in _get_detailed_lookup().items():
+        converted = _convert_detailed_to_litellm(slug, details)
+        models[converted["model_name"]] = {
+            **models.get(converted["model_name"], {}),
+            **converted["model_info"],
+        }
+
     return models
 
 


### PR DESCRIPTION
## Summary
- support canonical name helper in CLI
- allow canonical name helper to return `None`
- register OpenAI models using the detailed spec
- index all pricing snapshots from the bundled OpenAI dataset

## Testing
- `make checku`


------
https://chatgpt.com/codex/tasks/task_e_683c597982e88331a8f040d5e15a33cd