### PR TITLE
Support x.ai model cache

### DIFF
--- a/scripts/update_model_cache.py
+++ b/scripts/update_model_cache.py
@@ -26,6 +26,11 @@ def sort_openai_data(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def sort_xai_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Return ``data`` with models sorted by creation time."""
+    return sort_openai_data(data)
+
+
 def sort_anthropic_data(data: dict[str, Any]) -> dict[str, Any]:
     """Return ``data`` with models sorted by creation time when available."""
     models = data.get("data", [])
@@ -49,6 +54,7 @@ def sort_openrouter_data(data: dict[str, Any]) -> dict[str, Any]:
 
 SORTERS: dict[str, callable[[dict[str, Any]], dict[str, Any]]] = {
     "openai": sort_openai_data,
+    "xai": sort_xai_data,
     "anthropic": sort_anthropic_data,
     "gemini": sort_gemini_data,
     "openrouter": sort_openrouter_data,
@@ -91,6 +97,16 @@ def main(force: bool = False) -> None:
             headers["Authorization"] = f"Bearer {api_key}"
         data = fetch("https://api.openai.com/v1/models", headers=headers)
         write_json(openai_path, data)
+
+    # XAI
+    xai_path = get_data_file("xai")
+    if force or needs_update(xai_path):
+        headers = {}
+        api_key = os.getenv("XAI_API_KEY", "")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        data = fetch("https://api.x.ai/v1/models", headers=headers)
+        write_json(xai_path, data)
 
     # Anthropic
     anthropic_path = get_data_file("anthropic")

--- a/tests/test_model_registration/test_cache_sorting.py
+++ b/tests/test_model_registration/test_cache_sorting.py
@@ -44,3 +44,11 @@ def test_sort_openrouter(tmp_path):
     um.write_json(path, data)
     saved = json.loads(path.read_text())
     assert [m["id"] for m in saved["data"]] == ["a", "b"]
+
+
+def test_sort_xai(tmp_path):
+    data = {"data": [{"id": "b", "created": 2}, {"id": "a", "created": 1}]}
+    path = tmp_path / "xai.json"
+    um.write_json(path, data)
+    saved = json.loads(path.read_text())
+    assert [m["id"] for m in saved["data"]] == ["a", "b"]


### PR DESCRIPTION
## Summary
- scrape the x.ai model list in `update_model_cache`
- keep provider output sorted
- test x.ai sorter

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_6847c14fd0c483318b629aea7419c76b