### PR TITLE
Add Mistral model scraping

### DIFF
--- a/bulkllm/model_registration/data/mistral.json
+++ b/bulkllm/model_registration/data/mistral.json
@@ -1,0 +1,25 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "id": "mistral-small",
+      "object": "model",
+      "created": 0,
+      "owned_by": "mistralai",
+      "capabilities": {
+        "completion_chat": true,
+        "completion_fim": false,
+        "function_calling": true,
+        "fine_tuning": false,
+        "vision": true
+      },
+      "name": "Mistral Small",
+      "description": "Small model",
+      "max_context_length": 32768,
+      "aliases": [],
+      "deprecation": null,
+      "default_model_temperature": 0,
+      "type": "base"
+    }
+  ]
+}

--- a/bulkllm/model_registration/main.py
+++ b/bulkllm/model_registration/main.py
@@ -5,6 +5,7 @@ from bulkllm.model_registration.anthropic import (
     register_anthropic_models_with_litellm,
 )
 from bulkllm.model_registration.gemini import register_gemini_models_with_litellm
+from bulkllm.model_registration.mistral import register_mistral_models_with_litellm
 from bulkllm.model_registration.openai import register_openai_models_with_litellm
 from bulkllm.model_registration.openrouter import register_openrouter_models_with_litellm
 from bulkllm.model_registration.utils import bulkllm_register_models
@@ -65,4 +66,5 @@ def register_models():
     register_openai_models_with_litellm()
     register_anthropic_models_with_litellm()
     register_gemini_models_with_litellm()
+    register_mistral_models_with_litellm()
     bulkllm_register_models(manual_model_registrations, source="manual")

--- a/bulkllm/model_registration/mistral.py
+++ b/bulkllm/model_registration/mistral.py
@@ -1,0 +1,75 @@
+import logging
+import os
+from functools import cache
+from typing import Any
+
+import requests
+
+from bulkllm.model_registration.utils import (
+    bulkllm_register_models,
+    load_cached_provider_data,
+    save_cached_provider_data,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def convert_mistral_to_litellm(mistral_model: dict[str, Any]) -> dict[str, Any] | None:
+    """Convert a Mistral model dict to LiteLLM format."""
+    model_id = mistral_model.get("id")
+    if not model_id:
+        logger.warning("Skipping model due to missing id: %s", mistral_model)
+        return None
+
+    litellm_model_name = f"mistral/{model_id}"
+
+    model_info = {
+        "litellm_provider": "mistral",
+        "mode": "chat",
+    }
+
+    context = mistral_model.get("max_context_length")
+    if context is not None:
+        model_info["max_input_tokens"] = context
+
+    caps = mistral_model.get("capabilities", {})
+    if caps.get("function_calling"):
+        model_info["supports_function_calling"] = True
+    if caps.get("vision"):
+        model_info["supports_vision"] = True
+
+    return {"model_name": litellm_model_name, "model_info": model_info}
+
+
+@cache
+def get_mistral_models(*, use_cached: bool = True) -> dict[str, Any]:
+    """Return models from the Mistral list endpoint or cached data."""
+    if use_cached:
+        try:
+            data = load_cached_provider_data("mistral")
+        except FileNotFoundError:
+            use_cached = False
+    if not use_cached:
+        url = "https://api.mistral.ai/v1/models"
+        api_key = os.getenv("MISTRAL_API_KEY", "")
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        try:
+            resp = requests.get(url, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            save_cached_provider_data("mistral", data)
+        except requests.RequestException as exc:  # noqa: PERF203 - broad catch ok here
+            logger.warning("Failed to fetch Mistral models: %s", exc)
+            return {}
+    models: dict[str, Any] = {}
+    for item in data.get("data", []):
+        converted = convert_mistral_to_litellm(item)
+        if converted:
+            models[converted["model_name"]] = converted["model_info"]
+    return models
+
+
+@cache
+def register_mistral_models_with_litellm() -> None:
+    """Fetch and register Mistral models with LiteLLM."""
+    bulkllm_register_models(get_mistral_models(), source="mistral")

--- a/scripts/update_model_cache.py
+++ b/scripts/update_model_cache.py
@@ -52,12 +52,20 @@ def sort_openrouter_data(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def sort_mistral_data(data: dict[str, Any]) -> dict[str, Any]:
+    """Return ``data`` with models sorted by creation time."""
+    models = data.get("data", [])
+    data["data"] = sorted(models, key=lambda m: m.get("created", 0))
+    return data
+
+
 SORTERS: dict[str, callable[[dict[str, Any]], dict[str, Any]]] = {
     "openai": sort_openai_data,
     "xai": sort_xai_data,
     "anthropic": sort_anthropic_data,
     "gemini": sort_gemini_data,
     "openrouter": sort_openrouter_data,
+    "mistral": sort_mistral_data,
 }
 
 
@@ -134,6 +142,16 @@ def main(force: bool = False) -> None:
     if force or needs_update(openrouter_path):
         data = fetch("https://openrouter.ai/api/v1/models")
         write_json(openrouter_path, data)
+
+    # Mistral
+    mistral_path = get_data_file("mistral")
+    if force or needs_update(mistral_path):
+        headers = {}
+        api_key = os.getenv("MISTRAL_API_KEY", "")
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        data = fetch("https://api.mistral.ai/v1/models", headers=headers)
+        write_json(mistral_path, data)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual script

--- a/tests/test_model_registration/test_cache_sorting.py
+++ b/tests/test_model_registration/test_cache_sorting.py
@@ -52,3 +52,11 @@ def test_sort_xai(tmp_path):
     um.write_json(path, data)
     saved = json.loads(path.read_text())
     assert [m["id"] for m in saved["data"]] == ["a", "b"]
+
+
+def test_sort_mistral(tmp_path):
+    data = {"data": [{"id": "b", "created": 2}, {"id": "a", "created": 1}]}
+    path = tmp_path / "mistral.json"
+    um.write_json(path, data)
+    saved = json.loads(path.read_text())
+    assert [m["id"] for m in saved["data"]] == ["a", "b"]

--- a/tests/test_model_registration/test_conversions.py
+++ b/tests/test_model_registration/test_conversions.py
@@ -1,5 +1,6 @@
 from bulkllm.model_registration.anthropic import convert_anthropic_to_litellm
 from bulkllm.model_registration.gemini import convert_gemini_to_litellm
+from bulkllm.model_registration.mistral import convert_mistral_to_litellm
 from bulkllm.model_registration.openai import convert_openai_to_litellm
 
 
@@ -57,5 +58,24 @@ def test_convert_gemini():
             "max_input_tokens": 2048,
             "max_output_tokens": 4096,
             "supports_prompt_caching": True,
+        },
+    }
+
+
+def test_convert_mistral():
+    sample = {
+        "id": "mistral-small",
+        "max_context_length": 8192,
+        "capabilities": {"function_calling": True, "vision": True},
+    }
+    result = convert_mistral_to_litellm(sample)
+    assert result == {
+        "model_name": "mistral/mistral-small",
+        "model_info": {
+            "litellm_provider": "mistral",
+            "mode": "chat",
+            "max_input_tokens": 8192,
+            "supports_function_calling": True,
+            "supports_vision": True,
         },
     }

--- a/tests/test_model_registration/test_providers.py
+++ b/tests/test_model_registration/test_providers.py
@@ -4,6 +4,7 @@ import requests
 from bulkllm.model_registration import utils
 from bulkllm.model_registration.anthropic import get_anthropic_models
 from bulkllm.model_registration.gemini import get_gemini_models
+from bulkllm.model_registration.mistral import get_mistral_models
 from bulkllm.model_registration.openai import get_openai_models
 
 
@@ -85,4 +86,25 @@ def test_get_gemini_models_network(monkeypatch):
     assert "gemini/gemini-1.5-flash-001" in models
     info = models["gemini/gemini-1.5-flash-001"]
     assert info["litellm_provider"] == "gemini"
+    assert info["mode"] == "chat"
+
+
+def test_get_mistral_models_network(monkeypatch):
+    sample = {
+        "object": "list",
+        "data": [
+            {
+                "id": "mistral-small",
+                "object": "model",
+                "created": 0,
+                "owned_by": "mistralai",
+            }
+        ],
+    }
+    get_mistral_models.cache_clear()
+    _patch_get(monkeypatch, sample)
+    models = get_mistral_models()
+    assert "mistral/mistral-small" in models
+    info = models["mistral/mistral-small"]
+    assert info["litellm_provider"] == "mistral"
     assert info["mode"] == "chat"


### PR DESCRIPTION
## Summary
- support Mistral provider in model cache updater
- register Mistral models with LiteLLM
- implement Mistral model conversion/lookup
- add cached sample Mistral models
- test the new provider

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_68485120a6f08331a548ddc835c373a0