### PR TITLE
Add list-canonical-models command

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -4,6 +4,13 @@ import litellm
 import typer
 
 from bulkllm.llm_configs import create_model_configs
+from bulkllm.model_registration import (
+    anthropic,
+    gemini,
+    mistral,
+    openai,
+    openrouter,
+)
 from bulkllm.model_registration.canonical import _canonical_model_name
 from bulkllm.model_registration.main import register_models
 from bulkllm.rate_limiter import RateLimiter
@@ -38,6 +45,30 @@ def list_unique_models() -> None:
         typer.echo(name)
 
     print(f"Total unique models: {len(unique)}")
+
+
+@app.command("list-canonical-models")
+def list_canonical_models() -> None:
+    """List canonical models from direct provider scrapes."""
+    models = {}
+    providers = [
+        openai.get_openai_models,
+        anthropic.get_anthropic_models,
+        gemini.get_gemini_models,
+        mistral.get_mistral_models,
+        openrouter.get_openrouter_models,
+    ]
+    for get_models in providers:
+        models.update(get_models())
+
+    unique: set[str] = set()
+    for model, model_info in models.items():
+        canonical = _canonical_model_name(model, model_info)
+        if canonical is None:
+            continue
+        unique.add(canonical)
+    for name in sorted(unique):
+        typer.echo(name)
 
 
 @app.command("list-missing-rate-limits")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,3 +133,39 @@ def test_list_unique_models(monkeypatch):
     assert lines.count("anthropic/claude-3") == 1
     assert "openrouter/anthropic/claude-3" not in lines
     assert "bedrock/anthropic.claude-3" not in lines
+
+
+def test_list_canonical_models(monkeypatch):
+    monkeypatch.setattr(
+        "bulkllm.cli.openai.get_openai_models",
+        lambda: {"openai/gpt": {"litellm_provider": "openai", "mode": "chat"}},
+    )
+    monkeypatch.setattr(
+        "bulkllm.cli.anthropic.get_anthropic_models",
+        lambda: {"anthropic/claude": {"litellm_provider": "anthropic", "mode": "chat"}},
+    )
+    monkeypatch.setattr(
+        "bulkllm.cli.gemini.get_gemini_models",
+        lambda: {"gemini/flash": {"litellm_provider": "gemini", "mode": "chat"}},
+    )
+    monkeypatch.setattr(
+        "bulkllm.cli.mistral.get_mistral_models",
+        lambda: {"mistral/small": {"litellm_provider": "mistral", "mode": "chat"}},
+    )
+    monkeypatch.setattr(
+        "bulkllm.cli.openrouter.get_openrouter_models",
+        lambda: {"openrouter/google/gamma": {"litellm_provider": "openrouter", "mode": "chat"}},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-canonical-models"])
+
+    assert result.exit_code == 0
+    lines = result.output.splitlines()
+    assert "openai/gpt" in lines
+    assert "anthropic/claude" in lines
+    assert "gemini/flash" in lines
+    assert "mistral/small" in lines
+    # openrouter canonicalisation drops the prefix
+    assert "google/gamma" in lines
+    assert "openrouter/google/gamma" not in lines


### PR DESCRIPTION
## Summary
- expose provider modules in CLI
- add `list-canonical-models` command that aggregates models from direct provider scrapes
- test listing canonical models via the CLI

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_6848642aa7288331a4c4e2752ad6cb14