### PR TITLE
Sort OpenRouter models deterministically

### DIFF
--- a/bulkllm/model_registration/openrouter.py
+++ b/bulkllm/model_registration/openrouter.py
@@ -65,7 +65,7 @@ def fetch_openrouter_data() -> dict[str, Any]:
     resp = requests.get(url)
     resp.raise_for_status()
     data = resp.json()
-    data["data"] = sorted(data.get("data", []), key=lambda m: m.get("created", 0))
+    data["data"] = sorted(data.get("data", []), key=lambda m: (m.get("created", 0), m.get("id")))
     save_cached_provider_data("openrouter", data)
     return data
 

--- a/tests/test_model_registration/test_provider_helpers.py
+++ b/tests/test_model_registration/test_provider_helpers.py
@@ -56,11 +56,17 @@ def test_fetch_gemini_data(monkeypatch):
 
 
 def test_fetch_openrouter_data(monkeypatch):
-    sample = {"data": [{"id": "b", "created": 2}, {"id": "a", "created": 1}]}
+    sample = {
+        "data": [
+            {"id": "b", "created": 1},
+            {"id": "a", "created": 1},
+            {"id": "c", "created": 2},
+        ]
+    }
     _patch_get(monkeypatch, sample)
     monkeypatch.setattr(openrouter, "save_cached_provider_data", lambda p, d: None)
     data = openrouter.fetch_openrouter_data()
-    assert [m["id"] for m in data["data"]] == ["a", "b"]
+    assert [m["id"] for m in data["data"]] == ["a", "b", "c"]
 
 
 def test_fetch_mistral_data(monkeypatch):


### PR DESCRIPTION
## Summary
- sort OpenRouter model list by creation time and id
- update provider helper tests

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_6848654aaf448331b0325dbfb88ec1d6