### PR TITLE
Handle alias OpenAI models

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -79,10 +79,16 @@ def list_canonical_models() -> None:
     # Keep only chat models
     scraped_models = {name: info for name, info in scraped_models.items() if info.get("mode") == "chat"}
 
+    alias_names = {
+        c
+        for a in openai.get_openai_aliases()
+        if (c := _canonical_model_name(a, {"litellm_provider": "openai", "mode": "chat"}))
+    }
+
     canonical_scraped: dict[str, dict] = {}
     for model, model_info in scraped_models.items():
         canonical = _canonical_model_name(model, model_info)
-        if canonical is None:
+        if canonical is None or canonical in alias_names:
             continue
         canonical_scraped.setdefault(canonical, model_info)
 
@@ -91,7 +97,7 @@ def list_canonical_models() -> None:
         if model_info.get("mode") != "chat":
             continue
         canonical = _canonical_model_name(model, model_info)
-        if canonical is None:
+        if canonical is None or canonical in alias_names:
             continue
         canonical_registered.setdefault(canonical, model_info)
 

--- a/bulkllm/model_registration/openai.py
+++ b/bulkllm/model_registration/openai.py
@@ -233,3 +233,20 @@ def get_openai_models(*, use_cached: bool = True) -> dict[str, Any]:
 def register_openai_models_with_litellm() -> None:
     """Fetch and register OpenAI models with LiteLLM."""
     bulkllm_register_models(get_openai_models(), source="openai")
+
+
+@cache
+def get_openai_aliases() -> set[str]:
+    """Return the set of aliased OpenAI model names."""
+
+    aliases: set[str] = set()
+    data = _load_detailed_data()
+    for item in data.get("pricing", []):
+        name = item.get("name") or item.get("slug")
+        if not name:
+            continue
+        snapshot = item.get("current_snapshot")
+        if snapshot and str(snapshot) != name:
+            aliases.add(f"openai/{name}")
+
+    return aliases


### PR DESCRIPTION
## Summary
- strip alias models from `list-canonical-models`
- expose `get_openai_aliases()` helper
- test alias removal

## Testing
- `make checku`


------
https://chatgpt.com/codex/tasks/task_e_684b1c77a0f083318426b9ef69d53c07