### PR TITLE
Use mistral alias data when listing canonical models

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -88,6 +88,11 @@ def list_canonical_models() -> None:
         for a in openai.get_openai_aliases()
         if (c := _canonical_model_name(a, {"litellm_provider": "openai", "mode": "chat"}))
     }
+    alias_names |= {
+        c
+        for a in mistral.get_mistral_aliases()
+        if (c := _canonical_model_name(a, {"litellm_provider": "mistral", "mode": "chat"}))
+    }
 
     canonical_scraped: dict[str, dict] = {}
     for model, model_info in scraped_models.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -305,6 +305,77 @@ def test_list_canonical_models_drops_aliases(monkeypatch):
     assert "openai/alias" not in table
 
 
+def test_list_canonical_models_drops_mistral_aliases(monkeypatch):
+    import litellm
+
+    monkeypatch.setattr(litellm, "model_cost", {})
+
+    monkeypatch.setattr("bulkllm.cli.openai.get_openai_models", dict)
+    monkeypatch.setattr("bulkllm.cli.anthropic.get_anthropic_models", dict)
+    monkeypatch.setattr("bulkllm.cli.gemini.get_gemini_models", dict)
+    monkeypatch.setattr(
+        "bulkllm.cli.mistral.get_mistral_models",
+        lambda: {
+            "mistral/base": {"litellm_provider": "mistral", "mode": "chat"},
+            "mistral/alias": {"litellm_provider": "mistral", "mode": "chat"},
+        },
+    )
+    monkeypatch.setattr("bulkllm.cli.openai.get_openai_aliases", set)
+    monkeypatch.setattr(
+        "bulkllm.cli.mistral.get_mistral_aliases",
+        lambda: {"mistral/alias"},
+    )
+
+    def fake_register_models() -> None:
+        litellm.model_cost["mistral/base"] = {
+            "litellm_provider": "mistral",
+            "mode": "chat",
+        }
+        litellm.model_cost["mistral/alias"] = {
+            "litellm_provider": "mistral",
+            "mode": "chat",
+        }
+
+    monkeypatch.setattr("bulkllm.cli.register_models", fake_register_models)
+    monkeypatch.setattr("bulkllm.model_registration.main.register_models", fake_register_models)
+    monkeypatch.setattr(
+        "bulkllm.cli.create_model_configs",
+        lambda: [
+            LLMConfig(
+                slug="base",
+                display_name="Base",
+                company_name="mistral",
+                litellm_model_name="mistral/base",
+                llm_family="base",
+                temperature=1,
+                max_tokens=1,
+                release_date=datetime.date(2025, 1, 1),
+            ),
+            LLMConfig(
+                slug="alias",
+                display_name="Alias",
+                company_name="mistral",
+                litellm_model_name="mistral/alias",
+                llm_family="alias",
+                temperature=1,
+                max_tokens=1,
+                release_date=datetime.date(2025, 2, 2),
+            ),
+        ],
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list-canonical-models"])
+
+    assert result.exit_code == 0
+    lines = [line.strip() for line in result.output.splitlines() if line.strip()]
+    rows = [line.split("|") for line in lines[2:]]  # skip header and divider
+    table = {cells[0].strip(): cells[1].strip() for cells in rows}
+
+    assert "mistral/base" in table
+    assert "mistral/alias" not in table
+
+
 def test_list_canonical_models_skips_xai_fast(monkeypatch):
     import litellm
 


### PR DESCRIPTION
## Summary
- expose `get_mistral_aliases()` to load alias names from cached Mistral data
- filter canonical model listing using Mistral aliases
- test that Mistral aliases are dropped when listing canonical models

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_684b6e525cd083319dcdae37fbaafbb6