### PR TITLE
fix openai aliases

### DIFF
--- a/tests/test_model_registration/test_openai.py
+++ b/tests/test_model_registration/test_openai.py
@@ -1,0 +1,6 @@
+from bulkllm.model_registration.openai import get_openai_aliases
+
+
+def test_gpt35_turbo_16k_alias_present():
+    aliases = get_openai_aliases()
+    assert "openai/gpt-3.5-turbo-16k" in aliases


### PR DESCRIPTION
## Summary
- dedupe `gpt-3.5-turbo-16k` by treating it as an alias of the versioned model
- test that the alias list includes the 16k model

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_684dd81c99a08331ab6fdc6f26f759b4