### PR TITLE
Fix CLI scraped_date column

### DIFF
--- a/bulkllm/cli.py
+++ b/bulkllm/cli.py
@@ -163,7 +163,6 @@ def list_canonical_models() -> None:
         info = canonical_registered.get(name, canonical_scraped[name])
         release_date = release_dates.get(name, "")
         created = created_dates.get(name, "")
-        created = ""
         rows.append([name, str(info.get("mode", "")), release_date, created])
 
     table = _tabulate(rows, headers=["model", "mode", "release_date", "scraped_date"])


### PR DESCRIPTION
## Summary
- remove stray override that blanked `scraped_date` in `list-canonical-models`

## Testing
- `make checku`


------
https://chatgpt.com/codex/tasks/task_e_684de9c4ce348331b0028f1aae4dc52f