### PR TITLE
Add negative token check in rate limiter

### DIFF
--- a/bulkllm/rate_limiter.py
+++ b/bulkllm/rate_limiter.py
@@ -322,6 +322,9 @@ class ModelRateLimit(BaseModel):
             f"Checking if can make request for {self.model_names} with estimated tokens: {desired_input_tokens}, {desired_output_tokens}"
         )
 
+        if desired_input_tokens < 0 or desired_output_tokens < 0:
+            raise ValueError("negative token counts are not allowed")
+
         if self.rpm and self.current_requests_in_window + 1 > self.rpm:
             logger.debug(f"Request count {self.current_requests_in_window} + 1 > rpm {self.rpm}, returning False")
             return False

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -13,6 +13,12 @@ def test_has_capacity_exceeds_itpm():
         limit.has_capacity(15, 0)
 
 
+def test_negative_tokens_rejected():
+    limit = ModelRateLimit(model_names=["m"])
+    with pytest.raises(ValueError, match="negative"):
+        limit.has_capacity(-1, 0)
+
+
 def test_reserve_record_usage_sync():
     limit = ModelRateLimit(model_names=["m"], rpm=2, tpm=50, itpm=50, otpm=50)
     with limit.reserve_capacity_sync(10, 5) as ctx:


### PR DESCRIPTION
## Summary
- validate negative token counts in `ModelRateLimit.has_capacity`
- test rejection of negative tokens

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_6866af5151f88331b15ea8c469b99609