### PR TITLE
Add cost estimate to list-configs

### DIFF
--- a/bulkllm/rate_limits.py
+++ b/bulkllm/rate_limits.py
@@ -290,6 +290,12 @@ DEFAULT_RATE_LIMITS: RateLimitConfig = [
         rpm=150,
         tpm=2_000_000,
     ),
+    # Mistral Models
+    ModelRateLimit(
+        model_names=["mistral/mistral-small-latest"],
+        rpm=600,
+        tpm=6_000_000,
+    ),
     # XAI Models
     ModelRateLimit(model_names=["xai/grok-2-1212"], rpm=8 * 60, tpm=90000),
     ModelRateLimit(


### PR DESCRIPTION
## Summary
- support input/output tokens in `list-configs`
- add rate limits for latest Mistral small model
- test estimated cost column

## Testing
- `make checku`

------
https://chatgpt.com/codex/tasks/task_e_6868850f36008331bac88932425ae262